### PR TITLE
Fix the Github OAuth Scope so that it doesn't get write access

### DIFF
--- a/routes/auth.router.js
+++ b/routes/auth.router.js
@@ -22,7 +22,7 @@ authRouter.get('/google/redirect', passport.authenticate('google'), AuthCtrl.oau
 authRouter.get(
   '/github',
   passport.authenticate('github', {
-    scope: ['user']
+    scope: ['read:user']
   })
 );
 


### PR DESCRIPTION
Figured it probably wasn't a very good idea to get write access to the users profile, so I changed it to read-only.

Didn't test it locally, however the scope of my token is `read:user` on the live site and it seems to be working fine.